### PR TITLE
Add JSON serialization support to PhysicalQuantity

### DIFF
--- a/src/PhysicalQuantity.php
+++ b/src/PhysicalQuantity.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Renfordt\UnitLib;
 
-abstract class PhysicalQuantity implements \Stringable
+abstract class PhysicalQuantity implements \Stringable, \JsonSerializable
 {
     public readonly float $nativeValue;
 
@@ -128,6 +128,50 @@ abstract class PhysicalQuantity implements \Stringable
     public function __toString(): string
     {
         return $this->originalValue.' '.$this->originalUnit->name;
+    }
+
+    /**
+     * Serialize to JSON-compatible array.
+     * Returns both original and native values for flexibility.
+     *
+     * @return array{value: float, unit: string, nativeValue: float, nativeUnit: string, class: string}
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'value' => $this->originalValue,
+            'unit' => $this->originalUnit->name,
+            'nativeValue' => $this->nativeValue,
+            'nativeUnit' => $this->nativeUnit->name,
+            'class' => static::class,
+        ];
+    }
+
+    /**
+     * Create a PhysicalQuantity from JSON data.
+     *
+     * @param array<string, mixed> $data
+     */
+    public static function fromJson(array $data): PhysicalQuantity
+    {
+        if (!isset($data['class'], $data['value'], $data['unit'])) {
+            throw new \InvalidArgumentException('Invalid JSON data: missing required fields (class, value, unit)');
+        }
+
+        $className = $data['class'];
+        if (!is_string($className)) {
+            throw new \InvalidArgumentException('Invalid JSON data: class must be a string');
+        }
+
+        if (!class_exists($className)) {
+            throw new \InvalidArgumentException("Invalid JSON data: class '{$className}' does not exist");
+        }
+
+        if (!is_subclass_of($className, PhysicalQuantity::class)) {
+            throw new \InvalidArgumentException("Invalid JSON data: class '{$className}' is not a PhysicalQuantity");
+        }
+
+        return new $className($data['value'], $data['unit']);
     }
 
     public function add(PhysicalQuantity $quantity): PhysicalQuantity

--- a/tests/SerializationTest.php
+++ b/tests/SerializationTest.php
@@ -1,0 +1,209 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Renfordt\UnitLib\Tests;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Renfordt\UnitLib\Length;
+use Renfordt\UnitLib\Mass;
+use Renfordt\UnitLib\PhysicalQuantity;
+use Renfordt\UnitLib\Temperature;
+use Renfordt\UnitLib\UnitOfMeasurement;
+
+#[CoversClass(PhysicalQuantity::class)]
+#[CoversClass(Length::class)]
+#[CoversClass(Mass::class)]
+#[CoversClass(Temperature::class)]
+#[CoversClass(UnitOfMeasurement::class)]
+final class SerializationTest extends TestCase
+{
+    public function test_json_serialize_returns_correct_structure(): void
+    {
+        $length = new Length(100, 'cm');
+        $data = $length->jsonSerialize();
+
+        $this->assertIsArray($data);
+        $this->assertArrayHasKey('value', $data);
+        $this->assertArrayHasKey('unit', $data);
+        $this->assertArrayHasKey('nativeValue', $data);
+        $this->assertArrayHasKey('nativeUnit', $data);
+        $this->assertArrayHasKey('class', $data);
+    }
+
+    public function test_json_serialize_preserves_original_values(): void
+    {
+        $length = new Length(100, 'cm');
+        $data = $length->jsonSerialize();
+
+        $this->assertEquals(100, $data['value']);
+        $this->assertEquals('cm', $data['unit']);
+    }
+
+    public function test_json_serialize_includes_native_values(): void
+    {
+        $length = new Length(100, 'cm');
+        $data = $length->jsonSerialize();
+
+        $this->assertEquals(1, $data['nativeValue']);
+        $this->assertEquals('m', $data['nativeUnit']);
+    }
+
+    public function test_json_serialize_includes_class_name(): void
+    {
+        $length = new Length(100, 'cm');
+        $data = $length->jsonSerialize();
+
+        $this->assertEquals(Length::class, $data['class']);
+    }
+
+    public function test_json_encode_works(): void
+    {
+        $length = new Length(100, 'cm');
+        $json = json_encode($length);
+
+        $this->assertIsString($json);
+        $this->assertStringContainsString('"value":100', $json);
+        $this->assertStringContainsString('"unit":"cm"', $json);
+    }
+
+    public function test_from_json_creates_correct_instance(): void
+    {
+        $data = [
+            'class' => Length::class,
+            'value' => 100,
+            'unit' => 'cm',
+        ];
+
+        $length = PhysicalQuantity::fromJson($data);
+
+        $this->assertInstanceOf(Length::class, $length);
+        $this->assertEquals(100, $length->originalValue);
+        $this->assertEquals('100 cm', (string) $length);
+    }
+
+    public function test_round_trip_serialization(): void
+    {
+        $original = new Length(1500, 'mm');
+
+        // Serialize
+        $json = json_encode($original);
+        $data = json_decode($json, true);
+
+        // Deserialize
+        $restored = PhysicalQuantity::fromJson($data);
+
+        $this->assertInstanceOf(Length::class, $restored);
+        $this->assertEquals($original->originalValue, $restored->originalValue);
+        $this->assertEquals((string) $original, (string) $restored);
+        $this->assertEquals($original->nativeValue, $restored->nativeValue);
+    }
+
+    public function test_from_json_throws_exception_for_missing_class(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('missing required fields');
+
+        PhysicalQuantity::fromJson([
+            'value' => 100,
+            'unit' => 'cm',
+        ]);
+    }
+
+    public function test_from_json_throws_exception_for_missing_value(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('missing required fields');
+
+        PhysicalQuantity::fromJson([
+            'class' => Length::class,
+            'unit' => 'cm',
+        ]);
+    }
+
+    public function test_from_json_throws_exception_for_missing_unit(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('missing required fields');
+
+        PhysicalQuantity::fromJson([
+            'class' => Length::class,
+            'value' => 100,
+        ]);
+    }
+
+    public function test_from_json_throws_exception_for_invalid_class(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('does not exist');
+
+        PhysicalQuantity::fromJson([
+            'class' => 'NonExistentClass',
+            'value' => 100,
+            'unit' => 'cm',
+        ]);
+    }
+
+    public function test_from_json_throws_exception_for_non_physical_quantity_class(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('is not a PhysicalQuantity');
+
+        PhysicalQuantity::fromJson([
+            'class' => \stdClass::class,
+            'value' => 100,
+            'unit' => 'cm',
+        ]);
+    }
+
+    public function test_serialization_works_with_different_quantity_types(): void
+    {
+        $quantities = [
+            new Length(100, 'cm'),
+            new Mass(1500, 'g'),
+            new Temperature(25, '°C'),
+        ];
+
+        foreach ($quantities as $quantity) {
+            $json = json_encode($quantity);
+            $data = json_decode($json, true);
+            $restored = PhysicalQuantity::fromJson($data);
+
+            $this->assertInstanceOf($quantity::class, $restored);
+            $this->assertEquals($quantity->originalValue, $restored->originalValue);
+        }
+    }
+
+    public function test_serialization_preserves_precision(): void
+    {
+        $length = new Length(3.141592653589793, 'm');
+
+        $json = json_encode($length);
+        $data = json_decode($json, true);
+        $restored = PhysicalQuantity::fromJson($data);
+
+        $this->assertEquals($length->originalValue, $restored->originalValue);
+    }
+
+    public function test_serialization_works_with_negative_values(): void
+    {
+        $temperature = new Temperature(-40, '°C');
+
+        $json = json_encode($temperature);
+        $data = json_decode($json, true);
+        $restored = PhysicalQuantity::fromJson($data);
+
+        $this->assertInstanceOf(Temperature::class, $restored);
+        $this->assertEquals(-40, $restored->originalValue);
+    }
+
+    public function test_serialization_includes_correct_native_unit_for_si_units(): void
+    {
+        $length = new Length(5, 'km');
+        $data = $length->jsonSerialize();
+
+        $this->assertEquals(5000, $data['nativeValue']);
+        $this->assertEquals('m', $data['nativeUnit']);
+    }
+}


### PR DESCRIPTION
### Description

This pull request introduces JSON serialization support to the `PhysicalQuantity` class. Highlights include:
- Implementation of `JsonSerializable` interface, enabling seamless JSON encoding and decoding.
- Methods:
  - `jsonSerialize()`: Returns an array containing value, unit, native value, native unit, and class information.
  - `fromJson()`: A static factory method for safe deserialization of JSON data.
- Enhanced functionality:
  - Round-trip serialization (encode → decode → fromJson) with precision integrity.
  - Validation of input data to prevent exploitation or code injection.
  - Support for type-safe deserialization using class metadata.
- Fully compliant with `json_encode()` functionality and equipped with robust PHPStan type annotations.

### Additional Details

- Contains extensive test coverage (16 tests), validating corner cases, different quantity types, and error handling.
- Improves flexibility by preserving both original and native values.
- Ensures compatibility and safe deserialization for automated systems or APIs.
